### PR TITLE
feat: add auto-indentation rules (indents.scm)

### DIFF
--- a/languages/apex/indents.scm
+++ b/languages/apex/indents.scm
@@ -1,0 +1,20 @@
+; Apex indentation rules for Zed
+;
+; Indent any node that uses braces, parens, or brackets as delimiters.
+
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indent
+(_ "[" "]" @end) @indent
+
+; Multi-line expressions: assignments, method chains, field access
+[
+  (assignment_expression)
+  (method_invocation)
+  (field_access)
+  (local_variable_declaration)
+  (field_declaration)
+] @indent
+
+; Block comments
+((block_comment) @indent
+  (#match? @indent "^/\\*"))


### PR DESCRIPTION
## Summary

- Adds `languages/apex/indents.scm` for syntax-aware auto-indentation in Zed
- Handles brace/paren/bracket-delimited blocks via Zed's `@indent`/`@end` capture system
- Adds multi-line continuation indent for assignments, method chains, field access, and declarations
- Adds block comment indentation

Closes #3

## Test plan

- [x] `npm test` passes — query compilation validates `indents.scm` against the grammar
- [x] Install as dev extension in Zed and verify:
  - Pressing Enter inside a class/method body indents correctly
  - Multi-line argument lists and formal parameters indent
  - Control flow blocks (if/else, for, while, try/catch, switch/when) indent
  - Closing `}` dedents to match the opening line
  - Inline SOQL `[SELECT ... FROM ...]` indents continuation lines
  - Block comments `/* ... */` indent continuation lines