### PR TITLE
feat: optimize outline and symbol search (tags.scm)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ node -e "const s = require('tree-sitter-sfapex'); console.log(s.apex.nodeTypeInf
 - `config.toml` bracket entries control editor auto-close behavior and are independent of `brackets.scm` grammar node types.
 - `folds.scm` uses `@fold` captures on named node types (e.g. `(class_body) @fold`). The query compilation test validates it automatically since it covers all `.scm` files under `languages/*/`.
 - `indents.scm` uses `@indent` and `@end` captures. The pattern `(_ "{" "}" @end) @indent` matches any node delimited by braces without naming the node type explicitly.
+- `tags.scm` should only include `@definition.*` captures for the Outline panel and symbol search. `@reference.*` captures for call sites, local variables, and object creation flood the outline with noise and are only useful with an LSP (which this extension does not provide).
 
 ## Git and issue workflow
 

--- a/languages/apex/tags.scm
+++ b/languages/apex/tags.scm
@@ -1,3 +1,9 @@
+; Apex outline and symbol captures for Zed
+;
+; Only @definition.* captures are included — @reference.* captures for call
+; sites and local variables produce too much noise in the Outline panel and
+; symbol search without an LSP to make them actionable.
+
 (class_declaration
   name: (identifier) @name) @definition.class
 
@@ -7,18 +13,14 @@
 (enum_declaration
   name: (identifier) @name) @definition.enum
 
-(method_invocation
-  name: (identifier) @name) @reference.call
+(enum_constant
+  name: (identifier) @name) @definition.constant
+
+(trigger_declaration
+  name: (identifier) @name) @definition.type
+
+(constructor_declaration
+  name: (identifier) @name) @definition.method
 
 (method_declaration
   name: (identifier) @name) @definition.method
-
-(interfaces
-  (type_list
-    (type_identifier ) @name)) @reference.implementation
-
-(local_variable_declaration
-  (type_identifier) @name ) @reference.class
-
-(object_creation_expression
-  type: (type_identifier) @name) @reference.class


### PR DESCRIPTION
## Summary

- Adds `constructor_declaration`, `trigger_declaration`, and `enum_constant` to the Outline panel
- Removes all `@reference.*` captures (method call sites, local variable declarations, object creation expressions) — they flood symbol search with noise and are only useful with an LSP, which this extension does not provide

Closes #5

## Test plan

- [x] `npm test` passes — query compilation validates `tags.scm` against the grammar
- [ ] Install as dev extension in Zed and verify:
  - Outline panel shows classes, interfaces, enums, enum constants, triggers, constructors, and methods
  - Symbol search (`cmd+t`) returns only structural declarations, not every call site or local variable